### PR TITLE
Fix unused ImageIcon import

### DIFF
--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState } from 'react'
-import { Package, ImageIcon, Loader2 } from 'lucide-react'
+import { Package, Loader2 } from 'lucide-react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 
 interface ProductImageProps {


### PR DESCRIPTION
This pull request makes a minor change to the `src/components/ProductImage.tsx` file. The unused `ImageIcon` import from the `lucide-react` library has been removed to clean up the code.