### PR TITLE
🐛 Fix: Prevent form submission when changing product images

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -177,6 +177,7 @@ export const ImageUpload = ({
               <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-50 transition-opacity rounded-lg flex items-center justify-center">
                 <div className="opacity-0 group-hover:opacity-100 transition-opacity flex gap-2">
                   <Button
+                    type="button"
                     variant="secondary"
                     size="sm"
                     onClick={handleClick}
@@ -186,6 +187,7 @@ export const ImageUpload = ({
                     Cambiar
                   </Button>
                   <Button
+                    type="button"
                     variant="destructive"
                     size="sm"
                     onClick={handleRemoveImage}


### PR DESCRIPTION
- Add type='button' to image upload buttons (Change/Remove)
- This prevents the edit form from submitting when user tries to change product images
- Fixes issue where editing a product and replacing the photo returns to main menu